### PR TITLE
Make a HeaderFieldInfo trait

### DIFF
--- a/src/epan.rs
+++ b/src/epan.rs
@@ -145,48 +145,58 @@ impl Debug for FValue<'_> {
     }
 }
 
-#[derive(Debug,Clone)]
-pub enum HeaderFieldStrings
-{
+/// Enum to specify what type strings to use during the dissection.
+#[derive(Debug, Clone)]
+pub enum HeaderFieldStrings {
+    /// No string representation for the decoded value.
     None,
+
+    /// Lookup using u32 as index.
     ValueString(Vec<(u32, String)>),
+
+    /// Lookup using u64 as index.
     Value64String(Vec<(u64, String)>),
+
+    /// Lookup using a range.
     RangeString(Vec<((u32, u32), String)>),
+    // There's some more, that are not supported right now.
     // string-string
     // ext string
 }
 
-pub trait HeaderFieldInfo : Debug {
+/// Trait to represent a Header Field Info. This is what the user should provide to specify the
+/// dissection fields. It gets converted to the [`proto::header_field_info`] struct.
+pub trait HeaderFieldInfo: Debug {
+    /// The human readable name for this header field. ('My Integer')
     fn name(&self) -> String;
 
+    /// The abbreviation used for filters. ("proto.my_integer")
     fn abbrev(&self) -> String;
 
-    fn feature_type(&self) -> ftypes::ftenum
-    {
+    /// The feature type for this entry.
+    fn feature_type(&self) -> ftypes::ftenum {
         Default::default()
     }
-    fn display_type(&self) -> FieldDisplay
-    {
+
+    /// Specifies how this entry should be displayed.
+    fn display_type(&self) -> FieldDisplay {
         FieldDisplay::BASE_NONE
     }
 
-    fn strings(&self) -> HeaderFieldStrings
-    {
+    /// Strings to look up from after dissection.
+    fn strings(&self) -> HeaderFieldStrings {
         HeaderFieldStrings::None
     }
 
-    fn bitmask(&self) -> u64
-    {
+    /// Bitmask of interesting bits.
+    fn bitmask(&self) -> u64 {
         0
     }
 
-    fn blurb(&self) -> Option<String>
-    {
+    fn blurb(&self) -> Option<String> {
         None
     }
 }
-
-
 
 /// Struct to represent header field information, serves as a read only wrapper around the `header_field_info` C struct.
 pub struct WrappedHeaderFieldInfo {
@@ -201,8 +211,6 @@ impl WrappedHeaderFieldInfo {
         }
         return Box::new(WrappedHeaderFieldInfo { hfi: header_field_info });
     }
-
-    
 }
 
 impl HeaderFieldInfo for WrappedHeaderFieldInfo {

--- a/src/epan.rs
+++ b/src/epan.rs
@@ -145,6 +145,17 @@ impl Debug for FValue<'_> {
     }
 }
 
+#[derive(Debug,Clone)]
+pub enum HeaderFieldStrings
+{
+    None,
+    ValueString(Vec<(u32, String)>),
+    Value64String(Vec<(u64, String)>),
+    RangeString(Vec<((u32, u32), String)>),
+    // string-string
+    // ext string
+}
+
 pub trait HeaderFieldInfo : Debug {
     fn name(&self) -> String;
 
@@ -159,9 +170,9 @@ pub trait HeaderFieldInfo : Debug {
         FieldDisplay::BASE_NONE
     }
 
-    fn strings(&self) -> Option<Vec<(u32, String)>>
+    fn strings(&self) -> HeaderFieldStrings
     {
-        None
+        HeaderFieldStrings::None
     }
 
     fn bitmask(&self) -> u64
@@ -227,7 +238,7 @@ impl HeaderFieldInfo for WrappedHeaderFieldInfo {
     /// Obtain the field display enum.
     fn display_type(&self) -> proto::FieldDisplay {
         unsafe {
-            return (*self.hfi).display;
+            return (*self.hfi).display.into();
         }
     }
 }

--- a/src/epan.rs
+++ b/src/epan.rs
@@ -35,6 +35,7 @@ pub mod packet_info;
 pub mod proto;
 pub mod range;
 pub mod tvbuff;
+pub mod value_string;
 
 pub type FieldType = ftypes::ftenum;
 pub type FieldDisplay = proto::FieldDisplay;
@@ -158,7 +159,7 @@ pub trait HeaderFieldInfo : Debug {
         FieldDisplay::BASE_NONE
     }
 
-    fn strings(&self) -> Option<Vec<(i64, String)>>
+    fn strings(&self) -> Option<Vec<(u32, String)>>
     {
         None
     }

--- a/src/epan/proto.rs
+++ b/src/epan/proto.rs
@@ -61,6 +61,37 @@ impl FieldDisplay {
     pub const BASE_FLOAT: FieldDisplay = FieldDisplay::BASE_NONE;
     pub const STR_UNICODE: FieldDisplay = FieldDisplay::BASE_NONE;
 }
+impl From<&FieldDisplay> for i32 {
+    fn from(z: &FieldDisplay) -> Self {
+        *z as i32
+    }
+}
+impl From<i32> for FieldDisplay {
+    fn from(z: i32) -> Self {
+        match z & 0xff
+        {
+            0 => FieldDisplay::BASE_NONE,
+            1 => FieldDisplay::BASE_DEC,
+            2 => FieldDisplay::BASE_HEX,
+            3 => FieldDisplay::BASE_OCT,
+            4 => FieldDisplay::BASE_DEC_HEX,
+            5 => FieldDisplay::BASE_HEX_DEC,
+            6 => FieldDisplay::BASE_CUSTOM,
+            7 => FieldDisplay::STR_UNICODE,
+            8 => FieldDisplay::SEP_DOT,
+            9 => FieldDisplay::SEP_DASH,
+            10 => FieldDisplay::SEP_COLON,
+            11 => FieldDisplay::SEP_SPACE,
+            12 => FieldDisplay::BASE_NETMASK,
+            13 => FieldDisplay::BASE_PT_UDP,
+            14 => FieldDisplay::BASE_PT_TCP,
+            15 => FieldDisplay::BASE_PT_DCCP,
+            16 => FieldDisplay::BASE_PT_SCTP,
+            17 => FieldDisplay::BASE_OUI,
+            _=> FieldDisplay::BASE_NONE
+        }
+    }
+}
 
 #[repr(i32)]
 #[derive(Clone, Copy, Debug)]
@@ -117,7 +148,7 @@ pub struct header_field_info {
     pub name: *const libc::c_char,
     pub abbrev: *const libc::c_char,
     pub type_: ftenum,
-    pub display: FieldDisplay,
+    pub display: libc::c_int,
     pub strings: *const libc::c_void,
     pub bitmask: u64,
     pub blurb: *const libc::c_char,
@@ -135,7 +166,7 @@ impl Default for header_field_info {
             name: 0 as *const libc::c_char,
             abbrev: 0 as *const libc::c_char,
             type_: Default::default(),
-            display: FieldDisplay::BASE_NONE,
+            display: (&FieldDisplay::BASE_NONE).into(),
             strings: 0 as *const libc::c_char as *const libc::c_void,
             bitmask: 0,
             blurb: 0 as *const libc::c_char,

--- a/src/epan/proto.rs
+++ b/src/epan/proto.rs
@@ -62,6 +62,24 @@ impl FieldDisplay {
     pub const STR_UNICODE: FieldDisplay = FieldDisplay::BASE_NONE;
 }
 
+#[repr(i32)]
+#[derive(Clone, Copy, Debug)]
+pub enum FieldDisplayFlags {
+    /* Following constants have to be ORed with a field_display_e when dissector
+    * want to use specials value-string MACROs for a header_field_info */
+    RANGE_STRING = 0x0100,
+    EXT_STRING = 0x0200,
+    VAL64_STRING = 0x0400,
+    ALLOW_ZERO = 0x0800,  /*< Display <none> instead of <MISSING> for zero sized byte array */
+    UNIT_STRING = 0x1000,  /*< Add unit text to the field value */
+    NO_DISPLAY_VALUE = 0x2000,  /*< Just display the field name with no value.  Intended for
+                                 byte arrays or header fields above a subtree */
+    PROTOCOL_INFO = 0x4000,  /*< protocol_t in [FIELDCONVERT].  Internal use only. */
+    SPECIAL_VALS = 0x8000,  /*< field will not display "Unknown" if value_string match is not found */
+}
+
+
+
 #[repr(C)]
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -100,7 +118,7 @@ pub struct header_field_info {
     pub abbrev: *const libc::c_char,
     pub type_: ftenum,
     pub display: FieldDisplay,
-    pub strings: *const libc::c_char, // actually void ptr
+    pub strings: *const libc::c_void,
     pub bitmask: u64,
     pub blurb: *const libc::c_char,
 
@@ -118,7 +136,7 @@ impl Default for header_field_info {
             abbrev: 0 as *const libc::c_char,
             type_: Default::default(),
             display: FieldDisplay::BASE_NONE,
-            strings: 0 as *const libc::c_char,
+            strings: 0 as *const libc::c_char as *const libc::c_void,
             bitmask: 0,
             blurb: 0 as *const libc::c_char,
             id: -1,

--- a/src/epan/proto.rs
+++ b/src/epan/proto.rs
@@ -68,8 +68,7 @@ impl From<&FieldDisplay> for i32 {
 }
 impl From<i32> for FieldDisplay {
     fn from(z: i32) -> Self {
-        match z & 0xff
-        {
+        match z & 0xff {
             0 => FieldDisplay::BASE_NONE,
             1 => FieldDisplay::BASE_DEC,
             2 => FieldDisplay::BASE_HEX,
@@ -88,7 +87,7 @@ impl From<i32> for FieldDisplay {
             15 => FieldDisplay::BASE_PT_DCCP,
             16 => FieldDisplay::BASE_PT_SCTP,
             17 => FieldDisplay::BASE_OUI,
-            _=> FieldDisplay::BASE_NONE
+            _ => FieldDisplay::BASE_NONE,
         }
     }
 }
@@ -97,19 +96,17 @@ impl From<i32> for FieldDisplay {
 #[derive(Clone, Copy, Debug)]
 pub enum FieldDisplayFlags {
     /* Following constants have to be ORed with a field_display_e when dissector
-    * want to use specials value-string MACROs for a header_field_info */
+     * want to use specials value-string MACROs for a header_field_info */
     RANGE_STRING = 0x0100,
     EXT_STRING = 0x0200,
     VAL64_STRING = 0x0400,
     ALLOW_ZERO = 0x0800,  /*< Display <none> instead of <MISSING> for zero sized byte array */
-    UNIT_STRING = 0x1000,  /*< Add unit text to the field value */
-    NO_DISPLAY_VALUE = 0x2000,  /*< Just display the field name with no value.  Intended for
-                                 byte arrays or header fields above a subtree */
-    PROTOCOL_INFO = 0x4000,  /*< protocol_t in [FIELDCONVERT].  Internal use only. */
+    UNIT_STRING = 0x1000, /*< Add unit text to the field value */
+    NO_DISPLAY_VALUE = 0x2000, /*< Just display the field name with no value.  Intended for
+                          byte arrays or header fields above a subtree */
+    PROTOCOL_INFO = 0x4000, /*< protocol_t in [FIELDCONVERT].  Internal use only. */
     SPECIAL_VALS = 0x8000,  /*< field will not display "Unknown" if value_string match is not found */
 }
-
-
 
 #[repr(C)]
 #[allow(dead_code)]

--- a/src/epan/value_string.rs
+++ b/src/epan/value_string.rs
@@ -17,3 +17,34 @@ impl Default for value_string{
         value_string { value: 0, string: 0 as *const libc::c_char}
     }
 }
+
+// Same as value string, but then with 64 bit integer.
+#[repr(C)]
+#[derive(Copy, Debug, Clone)]
+pub struct value64_string {
+    pub value: libc::c_ulong,
+    pub string: *const libc::c_char,
+}
+
+impl Default for value64_string{
+    fn default() -> value64_string
+    {
+        value64_string { value: 0, string: 0 as *const libc::c_char}
+    }
+}
+
+// Use a range for each string.
+#[repr(C)]
+#[derive(Copy, Debug, Clone)]
+pub struct value_range_string {
+    pub value_min: libc::c_uint,
+    pub value_max: libc::c_uint,
+    pub string: *const libc::c_char,
+}
+
+impl Default for value_range_string{
+    fn default() -> value_range_string
+    {
+        value_range_string { value_min: 0, value_max: 0, string: 0 as *const libc::c_char}
+    }
+}

--- a/src/epan/value_string.rs
+++ b/src/epan/value_string.rs
@@ -1,0 +1,19 @@
+// Copyright 2021-2021, Ivor Wanders and the wireshark_dissector_rs contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// value_string.h holds quite some flavours of this.
+
+// Default value_string
+#[repr(C)]
+#[derive(Copy, Debug, Clone)]
+pub struct value_string {
+    pub value: libc::c_uint,
+    pub string: *const libc::c_char,
+}
+
+impl Default for value_string{
+    fn default() -> value_string
+    {
+        value_string { value: 0, string: 0 as *const libc::c_char}
+    }
+}

--- a/src/epan/value_string.rs
+++ b/src/epan/value_string.rs
@@ -11,10 +11,12 @@ pub struct value_string {
     pub string: *const libc::c_char,
 }
 
-impl Default for value_string{
-    fn default() -> value_string
-    {
-        value_string { value: 0, string: 0 as *const libc::c_char}
+impl Default for value_string {
+    fn default() -> value_string {
+        value_string {
+            value: 0,
+            string: 0 as *const libc::c_char,
+        }
     }
 }
 
@@ -26,10 +28,12 @@ pub struct value64_string {
     pub string: *const libc::c_char,
 }
 
-impl Default for value64_string{
-    fn default() -> value64_string
-    {
-        value64_string { value: 0, string: 0 as *const libc::c_char}
+impl Default for value64_string {
+    fn default() -> value64_string {
+        value64_string {
+            value: 0,
+            string: 0 as *const libc::c_char,
+        }
     }
 }
 
@@ -42,9 +46,12 @@ pub struct value_range_string {
     pub string: *const libc::c_char,
 }
 
-impl Default for value_range_string{
-    fn default() -> value_range_string
-    {
-        value_range_string { value_min: 0, value_max: 0, string: 0 as *const libc::c_char}
+impl Default for value_range_string {
+    fn default() -> value_range_string {
+        value_range_string {
+            value_min: 0,
+            value_max: 0,
+            string: 0 as *const libc::c_char,
+        }
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -30,6 +30,8 @@ impl From<&Box<dyn epan::HeaderFieldInfo>> for epan::proto::header_field_info {
                     string: util::perm_string_ptr(&s),
                 })
             }
+            // Needs to be terminated with a null entry
+            string_entries.push(Default::default());
             
             let value_str_ptr = (&string_entries[0]) as *const epan::value_string::value_string;
             // now, transmute that pointer to the const char*


### PR DESCRIPTION
This resolves  #3 .

In hindsight, I'm not too sure what the trait adds over the `BasicHeaderFieldInfo`, since I presume practically all implementations will end up looking like that. But lets go with it for now.

Screenshot produced with the `dummy` dissector:

![dissection_with_strings](https://user-images.githubusercontent.com/1732289/124166447-d6cec700-da70-11eb-8006-2999f18c8909.png)
